### PR TITLE
Removed phpactor

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -59,7 +59,6 @@ local servers = {
       "typescriptreact",
     },
   },
-  phpactor = {},
   html = {},
   lua_ls = {},
   prismals = {},


### PR DESCRIPTION
I have removed phpactor from the lsp.lua configuration, because an error occurred when installing the dotfiles.

Please review and accept the changes.